### PR TITLE
Loop 7 halt + CB drawdown trip fix

### DIFF
--- a/loop_7/health-t30.jsonl
+++ b/loop_7/health-t30.jsonl
@@ -1,0 +1,4 @@
+{"t":30,"ts":"2026-04-18T12:40:00Z","api":"ready","ws":"Streaming","paper_equity":70.75,"paper_delta_30min":-29.25,"signals":13,"orders":4,"stop_loss_triggered":1,"peak_equity":100.00,"peak_equity_fix":"verified",
+"cb":"Healthy","cb_should_be_tripped":true,"drawdown_pct":29.25,"max_drawdown_24h_pct":5.0,
+"red_flags":["bug_19_CB_no_trip_at_29pct_DD","strategy_algo_kayba_giriyor"],
+"errors":0,"verdict":"HALT_LOOP_7_FIX_AND_RESTART"}

--- a/loop_7/summary.md
+++ b/loop_7/summary.md
@@ -1,0 +1,21 @@
+# Loop 7 Özeti (HALT t30)
+
+## Süre: 30dk (erken)
+- Paper $100 → $70.75 (-%29.25 30dk)
+- Sinyal 13 / Order 4 / Stop-loss tetikledi 1
+- peakEquity $100 ✓ (Loop 6 fix doğru çalıştı)
+- ❌ CB Healthy ama DD %29.25 > max %5 — **bug #19 keşfi**
+
+## Bug #19 fix (uygulandı)
+**Çift root cause:**
+1. `RecordPeakEquitySnapshot` (Loop 6 yeni method) trip path EKLENMEMİŞ.
+2. `RecordTradeOutcomeCommandHandler` sadece `MaxDrawdownAllTimePct` (0.25) kontrol ediyordu, **`MaxDrawdown24hPct` (0.05) hiç bakılmıyordu**.
+
+**Fix:** Yeni private `RiskProfile.TripIfDrawdownBreached(now)` helper, hem RecordTradeOutcome hem RecordPeakEquitySnapshot çağırıyor. `effectiveCeiling = min(24h, allTime)`. CircuitBreakerTrippedEvent → DeactivateStrategy zinciri mevcut.
+
+Test 109→115 (+6).
+
+## Bug #20 (Loop 8 backlog) — Strateji algoritması kar etmiyor
+Loop 4-6-7 hepsi negatif. Param tweak yetersiz. Loop 8'de architect algoritma reform.
+
+## Karar: MUTATE → Loop 8

--- a/loop_8_backlog.md
+++ b/loop_8_backlog.md
@@ -1,0 +1,70 @@
+# Loop 8 Backlog (Kullanıcı Sipariş Listesi)
+
+**Kullanıcıdan:** 2026-04-18 ~13:25 UTC (Loop 7 t10 dolayında)
+**Talimat:** Loop 8 boot'ta plan + uygulama.
+
+---
+
+## #19 — Portföy Özeti tutarsız + İngilizce etiketler
+
+**Gözlem (ekran):**
+- Başlangıç Bakiyesi: $100.00
+- Mevcut Bakiye: $70.75
+- Realized Today: $-0.07
+- Unrealized: $-0.02
+- Fill Başarısı %: 100.0% (4 doldu / 4 toplam)
+
+**Tutarsızlık matematik:**
+- Beklenen: $100 + (-0.07) + (-0.02) = $99.91
+- Gösterilen: $70.75 → fark **-$29.25** açıklanmamış
+
+**Hipotezler:**
+1. **Mevcut Bakiye = cash balance**, açık pozisyonlar mark-to-market hesaba dahil değil. Yani:
+   - Cash balance = Starting + Realized - (open positions × entry price) = $100 - 0.07 - 29.18 ≈ $70.75
+   - Bu durumda doğru "portföy değeri" = cash + open positions@markPrice
+2. **Unrealized backend hesabı eksik:** sadece bir kısım pozisyon hesaba alınıyor, diğerleri 0 veriyor.
+3. **VirtualBalance.equity fonksiyonu yanlış:** ADR-0008 §8.4 ApplyFill/ApplyUnrealized akışı eksik.
+
+**Aday fix lokasyonu:**
+- `src/Application/Balances/Queries/GetBalances/` — cevap DTO
+- `src/Domain/Trading/VirtualBalance.cs` (varsa)
+- `src/Frontend/index.html:46` "Mevcut Bakiye" → ne göstermeli?
+
+**Etiket Türkçeleştirme:**
+- "Realized Today" → **"Bugünkü Realize"** veya **"Bugünkü Kar/Zarar"**
+- "Unrealized" → **"Gerçekleşmemiş"** veya **"Açık Pozisyon K/Z"**
+- "Fill Başarısı %" → kalabilir (yarı Türkçe), ama "Doluluk Oranı %" daha temiz
+- "Toplam İşlem" → kalabilir
+- "açık" → kalabilir (zaten TR)
+
+---
+
+## #20 — Aktif Sinyal × Trade sayı uyumsuzluğu
+
+**Gözlem (ekran):**
+- Aktif Sinyaller bölümünde 5 sinyal kart (BNB MeanRev x4, BTC Trend x1, Exit x1)
+- Toplam İşlem: 4 (1 açık)
+- Ekran zamanı: 15:24:01
+
+**Hipotezler:**
+1. **Aynı strateji aynı yön ardışık sinyal:** BNB-MeanRev "Long" sinyalleri 15:21, 15:22, 15:24 — ardışık aynı yön. PlaceOrder idempotent (clientOrderId aynı bar için aynı), ya da pozisyon zaten açık → yeni order yaratılmıyor. Doğru davranış.
+2. **Exit signal NotFound:** BNB Exit 15:16 → açık pozisyon yoksa NotFound, sessizce skip. Trade'e dönüşmüyor. Doğru davranış.
+3. **Sized qty 0 → SKIP:** Min notional altı veya equity 0 → trade yaratılmıyor. SystemEvent'lerden kontrol edilmeli (trade.sizing_skipped).
+
+**Asıl soru:** "Çok sinyal ama az trade" beklenen davranış mı, **bug mı?** Frontend'de "Aktif Sinyaller" bölümünün gerçek anlamı net değil — kullanıcı her sinyalin trade'e dönüşmesini bekleyebilir. UX clarification + log gözden geçirme.
+
+**Aday fix:**
+- Frontend `index.html` "Aktif Sinyaller" bölümüne her sinyal için **sonuç badge'i** ekle: "FILLED" / "SKIPPED (sizing)" / "EXIT (no_position)" / "DUPLICATE"
+- Backend SystemEvents tablosundan signal-to-order karar nedenlerini çek
+- Yeni endpoint? `/api/strategies/signals/recent-with-outcome` (sinyal + order durumu join)
+
+---
+
+## Kontrol Sırası (Loop 8 boot)
+
+1. Mevcut DB üzerinden tanı (DB silmeden):
+   - `/api/balances` ham veri vs UI hesaplaması karşılaştırma
+   - `/api/orders/history` son 20 + `/api/strategies/signals/latest` son 20 cross-reference
+2. Plan dosyası: `loop_8/plan.md`
+3. Uygulama (frontend-dev + backend-dev gerekirse)
+4. DB drop + Loop 8 normal cycle

--- a/src/Application/RiskProfiles/Commands/RecordTradeOutcome/RecordTradeOutcomeCommand.cs
+++ b/src/Application/RiskProfiles/Commands/RecordTradeOutcome/RecordTradeOutcomeCommand.cs
@@ -45,6 +45,7 @@ public sealed class RecordTradeOutcomeCommandHandler : IRequestHandler<RecordTra
             profile.CircuitBreakerStatus,
             profile.CurrentDrawdownPct);
 
+        var statusBefore = profile.CircuitBreakerStatus;
         profile.RecordTradeOutcome(request.RealizedPnl, request.EquityAfter, _clock.UtcNow);
 
         _logger.LogInformation(
@@ -55,36 +56,30 @@ public sealed class RecordTradeOutcomeCommandHandler : IRequestHandler<RecordTra
             profile.CurrentDrawdownPct,
             profile.MaxConsecutiveLosses);
 
-        if (profile.CircuitBreakerStatus == CircuitBreakerStatus.Healthy)
+        // Loop 8 bug #19: trip evaluation (consec losses + 24h/all-time drawdown) now
+        // lives in the domain (RiskProfile.RecordTradeOutcome → TripIfDrawdownBreached).
+        // The handler stays the audit voice so the Loop 5 grep contract still works.
+        if (statusBefore == CircuitBreakerStatus.Healthy
+            && profile.CircuitBreakerStatus == CircuitBreakerStatus.Tripped)
         {
-            var tripped = false;
-            string? reason = null;
-            if (profile.ConsecutiveLosses >= profile.MaxConsecutiveLosses)
-            {
-                tripped = true;
-                reason = $"consecutive_losses={profile.ConsecutiveLosses}";
-            }
-            else if (profile.CurrentDrawdownPct >= profile.MaxDrawdownAllTimePct)
-            {
-                tripped = true;
-                reason = $"drawdown={profile.CurrentDrawdownPct:P2}";
-            }
-
-            if (tripped)
-            {
-                profile.TripCircuitBreaker(reason!, profile.CurrentDrawdownPct, _clock.UtcNow);
-                _logger.LogWarning(
-                    "CB-AUDIT tripped mode={Mode} reason={Reason} consec={Consec}/{Max} drawdown={DD}",
-                    request.Mode, reason, profile.ConsecutiveLosses, profile.MaxConsecutiveLosses, profile.CurrentDrawdownPct);
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "CB-AUDIT not-tripped mode={Mode} consec={Consec}/{Max} drawdown={DD}/{DDCap}",
-                    request.Mode,
-                    profile.ConsecutiveLosses, profile.MaxConsecutiveLosses,
-                    profile.CurrentDrawdownPct, profile.MaxDrawdownAllTimePct);
-            }
+            _logger.LogWarning(
+                "CB-AUDIT tripped mode={Mode} reason={Reason} consec={Consec}/{Max} drawdown={DD} dd24h={DD24h} ddAll={DDAll}",
+                request.Mode,
+                profile.CircuitBreakerReason,
+                profile.ConsecutiveLosses, profile.MaxConsecutiveLosses,
+                profile.CurrentDrawdownPct,
+                profile.MaxDrawdown24hPct,
+                profile.MaxDrawdownAllTimePct);
+        }
+        else if (profile.CircuitBreakerStatus == CircuitBreakerStatus.Healthy)
+        {
+            _logger.LogInformation(
+                "CB-AUDIT not-tripped mode={Mode} consec={Consec}/{Max} drawdown={DD} dd24h={DD24h} ddAll={DDAll}",
+                request.Mode,
+                profile.ConsecutiveLosses, profile.MaxConsecutiveLosses,
+                profile.CurrentDrawdownPct,
+                profile.MaxDrawdown24hPct,
+                profile.MaxDrawdownAllTimePct);
         }
 
         await _db.SaveChangesAsync(ct);

--- a/src/Domain/RiskProfiles/RiskProfile.cs
+++ b/src/Domain/RiskProfiles/RiskProfile.cs
@@ -151,11 +151,12 @@ public sealed class RiskProfile : AggregateRoot<int>
     /// against a stale $99 peak and trips the CB at -43% when the real intraday
     /// drawdown was -71% from a peak that was never recorded.
     ///
-    /// This method is called by <see cref="Infrastructure.Risk.EquityPeakTrackerService"/>
-    /// on a periodic tick. It only ever ratchets <see cref="PeakEquity"/> upward and
-    /// rebases <see cref="CurrentDrawdownPct"/>; it does not raise events, change
-    /// <see cref="ConsecutiveLosses"/>, or trip the circuit breaker (those remain
-    /// the responsibility of <see cref="RecordTradeOutcome"/>).
+    /// Loop 7 → Loop 8 bug #19 fix: this method now also evaluates the drawdown
+    /// circuit-breaker. Previously trip evaluation lived only on
+    /// <see cref="RecordTradeOutcome"/>, so an intraday equity slide that crossed the
+    /// drawdown ceiling without a closed trade would never trip the CB. The tracker
+    /// is the only path that observes such slides, so it must own the drawdown trip.
+    /// Consecutive-losses trip remains exclusive to <see cref="RecordTradeOutcome"/>.
     /// </summary>
     public void RecordPeakEquitySnapshot(decimal currentEquity, DateTimeOffset now)
     {
@@ -175,6 +176,8 @@ public sealed class RiskProfile : AggregateRoot<int>
         }
 
         UpdatedAt = now;
+
+        TripIfDrawdownBreached(now);
     }
 
     public void RecordTradeOutcome(decimal realizedPnl, decimal equityAfter, DateTimeOffset now)
@@ -203,5 +206,46 @@ public sealed class RiskProfile : AggregateRoot<int>
 
         UpdatedAt = now;
         RaiseDomainEvent(new TradeOutcomeRecordedEvent(realizedPnl, ConsecutiveLosses));
+
+        if (CircuitBreakerStatus == CircuitBreakerStatus.Healthy
+            && ConsecutiveLosses >= MaxConsecutiveLosses)
+        {
+            TripCircuitBreaker(
+                $"consecutive_losses={ConsecutiveLosses}",
+                CurrentDrawdownPct,
+                now);
+            return;
+        }
+
+        TripIfDrawdownBreached(now);
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19: evaluates whether <see cref="CurrentDrawdownPct"/> has breached
+    /// the tighter of the 24h / all-time drawdown ceilings and trips the CB if so.
+    /// Both <see cref="RecordTradeOutcome"/> and <see cref="RecordPeakEquitySnapshot"/>
+    /// route through here so trip semantics stay identical regardless of the path that
+    /// observed the breach (trade close vs. intraday equity slide).
+    /// </summary>
+    private void TripIfDrawdownBreached(DateTimeOffset now)
+    {
+        if (CircuitBreakerStatus != CircuitBreakerStatus.Healthy)
+        {
+            return;
+        }
+
+        // Use the strictest configured ceiling. 24h is normally smaller (e.g. 5%) than
+        // the all-time fuse (e.g. 25%), so 24h fires first; but we keep the all-time
+        // check too in case a profile is reconfigured with a tighter all-time fuse.
+        var ceiling24h = MaxDrawdown24hPct;
+        var ceilingAll = MaxDrawdownAllTimePct;
+        var effectiveCeiling = ceiling24h < ceilingAll ? ceiling24h : ceilingAll;
+        var breachedScope = ceiling24h < ceilingAll ? "24h" : "all_time";
+
+        if (CurrentDrawdownPct >= effectiveCeiling)
+        {
+            var reason = $"drawdown_{breachedScope}={CurrentDrawdownPct:P2}>={effectiveCeiling:P2}";
+            TripCircuitBreaker(reason, CurrentDrawdownPct, now);
+        }
     }
 }

--- a/src/Infrastructure/Risk/EquityPeakTrackerService.cs
+++ b/src/Infrastructure/Risk/EquityPeakTrackerService.cs
@@ -31,6 +31,13 @@ namespace BinanceBot.Infrastructure.Risk;
 /// LiveMainnet is skipped because <see cref="EquitySnapshotProvider"/> always returns
 /// 0 there (ADR-0006 mainnet guard), and <c>RecordPeakEquitySnapshot</c> short-circuits
 /// on <c>currentEquity ≤ 0</c> anyway.
+///
+/// Loop 8 bug #19 update: <see cref="RiskProfile.RecordPeakEquitySnapshot"/> now also
+/// trips the drawdown circuit-breaker when the configured ceiling is breached. The
+/// tracker still does not pull that lever directly — it just persists, and the
+/// <see cref="ApplicationDbContext"/> publisher fans the
+/// <c>CircuitBreakerTrippedEvent</c> out to <c>CircuitBreakerTrippedHandler</c>
+/// (kill-switch deactivates active strategies).
 /// </summary>
 public sealed class EquityPeakTrackerService : BackgroundService
 {
@@ -111,6 +118,7 @@ public sealed class EquityPeakTrackerService : BackgroundService
             }
 
             var peakBefore = profile.PeakEquity;
+            var statusBefore = profile.CircuitBreakerStatus;
             profile.RecordPeakEquitySnapshot(equity, clock.UtcNow);
 
             if (profile.PeakEquity > peakBefore)
@@ -125,6 +133,18 @@ public sealed class EquityPeakTrackerService : BackgroundService
                 _logger.LogDebug(
                     "PEAK-TRACK mode={Mode} equity={Equity} peak={Peak} dd={DD}",
                     mode, equity, profile.PeakEquity, profile.CurrentDrawdownPct);
+                dirty++;
+            }
+
+            // Loop 8 bug #19: surface tracker-driven CB trips so operators don't have
+            // to grep across two log streams to reconstruct an intraday breach.
+            if (statusBefore == CircuitBreakerStatus.Healthy
+                && profile.CircuitBreakerStatus == CircuitBreakerStatus.Tripped)
+            {
+                _logger.LogWarning(
+                    "CB-AUDIT tripped-by-tracker mode={Mode} reason={Reason} equity={Equity} peak={Peak} dd={DD} dd24h={DD24h} ddAll={DDAll}",
+                    mode, profile.CircuitBreakerReason, equity, profile.PeakEquity,
+                    profile.CurrentDrawdownPct, profile.MaxDrawdown24hPct, profile.MaxDrawdownAllTimePct);
                 dirty++;
             }
         }

--- a/tests/Tests/Domain/RiskProfiles/RiskProfileTests.cs
+++ b/tests/Tests/Domain/RiskProfiles/RiskProfileTests.cs
@@ -1,5 +1,6 @@
 using BinanceBot.Domain.Common;
 using BinanceBot.Domain.RiskProfiles;
+using BinanceBot.Domain.RiskProfiles.Events;
 using FluentAssertions;
 
 namespace BinanceBot.Tests.Domain.RiskProfiles;
@@ -78,26 +79,24 @@ public class RiskProfileTests
 
     /// <summary>
     /// Loop 7 bug #17 — <see cref="RiskProfile.RecordPeakEquitySnapshot"/> contract:
-    /// only ever ratchets PeakEquity upward, rebases drawdown, never raises events,
-    /// never increments ConsecutiveLosses, never trips the CB. Models the live equity
-    /// stream that <c>EquityPeakTrackerService</c> feeds in.
+    /// ratchets PeakEquity upward and rebases drawdown without altering
+    /// ConsecutiveLosses. Loop 8 bug #19 update: it MAY trip the CB if the rebased
+    /// drawdown breaches the configured ceiling — this test stays safely under the
+    /// 24h ceiling (5%) so the CB stays Healthy.
     /// </summary>
     [Fact]
-    public void RecordPeakEquitySnapshot_RatchetsPeak_RebasesDrawdown_NoConsecChange()
+    public void RecordPeakEquitySnapshot_BelowCeiling_KeepsCbHealthy()
     {
         var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
 
-        // Loop 6 t30 spike: $195 unrealized peak with no closed trade.
-        rp.RecordPeakEquitySnapshot(195.25m, T0.AddMinutes(30));
-        rp.PeakEquity.Should().Be(195.25m);
-        rp.CurrentDrawdownPct.Should().Be(0m);
+        // Below-ceiling sequence: peak $100, dip to $97 → 3% dd < 5% ceiling.
+        rp.RecordPeakEquitySnapshot(100m, T0.AddMinutes(30));
+        rp.RecordPeakEquitySnapshot(97m, T0.AddMinutes(60));
+
+        rp.PeakEquity.Should().Be(100m);
+        rp.CurrentDrawdownPct.Should().BeApproximately(0.03m, 0.0001m);
         rp.ConsecutiveLosses.Should().Be(0);
         rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Healthy);
-
-        // Loop 6 t90 unwind: equity falls to $56.10 — drawdown rebased vs the live peak.
-        rp.RecordPeakEquitySnapshot(56.10m, T0.AddMinutes(90));
-        rp.PeakEquity.Should().Be(195.25m);
-        rp.CurrentDrawdownPct.Should().BeApproximately(0.7128m, 0.001m);
     }
 
     [Fact]
@@ -114,15 +113,121 @@ public class RiskProfileTests
     }
 
     [Fact]
-    public void RecordPeakEquitySnapshot_RaisesNoDomainEvents()
+    public void RecordPeakEquitySnapshot_BelowCeiling_RaisesNoDomainEvents()
     {
         var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
         rp.ClearDomainEvents();
 
-        rp.RecordPeakEquitySnapshot(150m, T0);
-        rp.RecordPeakEquitySnapshot(120m, T0.AddMinutes(1));
+        // 100 → 97 = 3% dd, well below the 5% 24h ceiling.
+        rp.RecordPeakEquitySnapshot(100m, T0);
+        rp.RecordPeakEquitySnapshot(97m, T0.AddMinutes(1));
 
         rp.DomainEvents.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — primary regression. Live trace observed
+    /// CurrentDrawdownPct=0.2925 with MaxDrawdown24hPct=0.05 yet
+    /// CircuitBreakerStatus stayed Healthy. Trip evaluation must now run in
+    /// RecordPeakEquitySnapshot, use the tighter of the 24h / all-time ceilings,
+    /// and raise CircuitBreakerTrippedEvent.
+    /// </summary>
+    [Fact]
+    public void RecordPeakEquitySnapshot_DrawdownBreaches24hCeiling_TripsCb()
+    {
+        var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0); // 24h=5%, all-time=25%
+        rp.ClearDomainEvents();
+
+        // Loop 7 t30 trace: peak $100 → equity $70.75 ⇒ 29.25% dd > 5% ceiling.
+        rp.RecordPeakEquitySnapshot(100m, T0);
+        rp.RecordPeakEquitySnapshot(70.75m, T0.AddMinutes(30));
+
+        rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        rp.CircuitBreakerReason.Should().NotBeNullOrWhiteSpace();
+        rp.CircuitBreakerReason.Should().Contain("24h");
+        rp.CurrentDrawdownPct.Should().BeApproximately(0.2925m, 0.0001m);
+
+        rp.DomainEvents.OfType<CircuitBreakerTrippedEvent>().Should().ContainSingle()
+            .Which.ObservedDrawdownPct.Should().BeApproximately(0.2925m, 0.0001m);
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — defensive: if the 24h ceiling is reconfigured higher than the
+    /// all-time fuse, the all-time fuse must still trip when crossed.
+    /// </summary>
+    [Fact]
+    public void RecordPeakEquitySnapshot_AllTimeIsTighterThan24h_TripsOnAllTime()
+    {
+        var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
+        // Reconfigure: 24h=10% (loose), all-time=8% (tighter than 24h).
+        rp.UpdateLimits(0.01m, 0.10m, 0.10m, 0.08m, 3, T0);
+        rp.ClearDomainEvents();
+
+        rp.RecordPeakEquitySnapshot(100m, T0);
+        rp.RecordPeakEquitySnapshot(91m, T0.AddMinutes(1)); // 9% dd
+
+        rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        rp.CircuitBreakerReason.Should().Contain("all_time");
+        rp.DomainEvents.OfType<CircuitBreakerTrippedEvent>().Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — once tripped, subsequent snapshots must not re-trip
+    /// (no duplicate CircuitBreakerTrippedEvent storm into the kill-switch handler).
+    /// </summary>
+    [Fact]
+    public void RecordPeakEquitySnapshot_AlreadyTripped_DoesNotReRaiseEvent()
+    {
+        var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
+
+        rp.RecordPeakEquitySnapshot(100m, T0);
+        rp.RecordPeakEquitySnapshot(70m, T0.AddMinutes(1)); // first trip
+        rp.ClearDomainEvents();
+
+        rp.RecordPeakEquitySnapshot(60m, T0.AddMinutes(2)); // deeper, but already tripped
+
+        rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        rp.DomainEvents.OfType<CircuitBreakerTrippedEvent>().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — RecordTradeOutcome was already supposed to evaluate trip
+    /// on the all-time ceiling. The fix unifies on the tighter of the two ceilings,
+    /// so a -29% close vs a $100 peak must trip on the 24h ceiling (5%) too.
+    /// </summary>
+    [Fact]
+    public void RecordTradeOutcome_DrawdownBreaches24hCeiling_TripsCb()
+    {
+        var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
+        rp.RecordTradeOutcome(0m, 100m, T0);          // peak=100
+        rp.ClearDomainEvents();
+
+        rp.RecordTradeOutcome(-29.25m, 70.75m, T0.AddMinutes(1));
+
+        rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        rp.CircuitBreakerReason.Should().Contain("24h");
+        rp.DomainEvents.OfType<CircuitBreakerTrippedEvent>().Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — consecutive-losses still wins when both conditions are true,
+    /// because the consec branch runs first (kill-switch reason is more actionable).
+    /// </summary>
+    [Fact]
+    public void RecordTradeOutcome_ConsecAndDrawdownBothBreached_ReasonIsConsec()
+    {
+        var rp = RiskProfile.CreateDefault(TradingMode.Paper, T0);
+        rp.RecordTradeOutcome(0m, 100m, T0);
+        rp.RecordTradeOutcome(-1m, 99m, T0.AddMinutes(1));
+        rp.RecordTradeOutcome(-1m, 98m, T0.AddMinutes(2));
+        rp.ClearDomainEvents();
+
+        // 3rd loss + a -29% slide in one shot.
+        rp.RecordTradeOutcome(-29m, 69m, T0.AddMinutes(3));
+
+        rp.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        rp.CircuitBreakerReason.Should().StartWith("consecutive_losses=");
+        rp.DomainEvents.OfType<CircuitBreakerTrippedEvent>().Should().ContainSingle();
     }
 
     [Fact]

--- a/tests/Tests/Infrastructure/Risk/EquityPeakTrackerServiceTests.cs
+++ b/tests/Tests/Infrastructure/Risk/EquityPeakTrackerServiceTests.cs
@@ -145,16 +145,49 @@ public class EquityPeakTrackerServiceTests
         paper.CurrentDrawdownPct.Should().Be(0m);
     }
 
+    /// <summary>
+    /// Loop 8 bug #19 — sequel: drawdown trip evaluation is now part of
+    /// RecordPeakEquitySnapshot, so an intraday equity slide that crosses the
+    /// 24h ceiling MUST flip the CB to Tripped during a tracker tick. Prior
+    /// version of this test asserted the opposite (Loop 7 contract);
+    /// rewritten to lock in the fixed behaviour.
+    /// </summary>
     [Fact]
-    public async Task Tick_DoesNotTripCircuitBreaker_EvenOnLargeDrawdown()
+    public async Task Tick_DrawdownAcross24hCeiling_TripsCircuitBreaker()
     {
-        // Risk-management policy belongs to RecordTradeOutcome; the tracker is read-only
-        // for CB state. A 70% live drawdown must NOT change CircuitBreakerStatus here.
+        var (svc, _, db) = BuildHarness(e =>
+        {
+            // Peak ratchets to 100, then unwinds to 70.75 (29.25% dd > 5% ceiling).
+            var seq = e.SetupSequence(x =>
+                x.GetEquityAsync(TradingMode.Paper, It.IsAny<CancellationToken>()));
+            seq.ReturnsAsync(100m).ReturnsAsync(70.75m);
+            e.Setup(x => x.GetEquityAsync(TradingMode.LiveTestnet, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(0m);
+        });
+
+        await svc.TickOnceAsync(CancellationToken.None);
+        await svc.TickOnceAsync(CancellationToken.None);
+
+        var paper = await db.RiskProfiles.AsNoTracking()
+            .FirstAsync(r => r.Id == (int)TradingMode.Paper);
+        paper.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Tripped);
+        paper.CircuitBreakerReason.Should().Contain("24h");
+        paper.CurrentDrawdownPct.Should().BeApproximately(0.2925m, 0.0001m);
+    }
+
+    /// <summary>
+    /// Loop 8 bug #19 — defence-in-depth: a small dip below the live peak must NOT
+    /// trip the CB. Confirms the trip path only fires when the configured ceiling
+    /// is actually breached, not merely whenever drawdown is non-zero.
+    /// </summary>
+    [Fact]
+    public async Task Tick_SmallDrawdownBelowCeiling_KeepsCbHealthy()
+    {
         var (svc, _, db) = BuildHarness(e =>
         {
             var seq = e.SetupSequence(x =>
                 x.GetEquityAsync(TradingMode.Paper, It.IsAny<CancellationToken>()));
-            seq.ReturnsAsync(200m).ReturnsAsync(50m);
+            seq.ReturnsAsync(100m).ReturnsAsync(97m); // 3% dd < 5% ceiling
             e.Setup(x => x.GetEquityAsync(TradingMode.LiveTestnet, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(0m);
         });
@@ -165,6 +198,6 @@ public class EquityPeakTrackerServiceTests
         var paper = await db.RiskProfiles.AsNoTracking()
             .FirstAsync(r => r.Id == (int)TradingMode.Paper);
         paper.CircuitBreakerStatus.Should().Be(CircuitBreakerStatus.Healthy);
-        paper.CurrentDrawdownPct.Should().BeGreaterThan(0.5m);
+        paper.CurrentDrawdownPct.Should().BeApproximately(0.03m, 0.0001m);
     }
 }


### PR DESCRIPTION
## Özet
Loop 7 t30'da halt — Paper -%29.25 ama CB Healthy (drawdown trip path hatası).

## Çift Root Cause
1. `RiskProfile.RecordPeakEquitySnapshot` (Loop 6'da eklenen intraday peak tracker) trip kontrolü içermiyordu — equity slide kapalı pozisyonsuz CB'yi atlatıyordu.
2. `RecordTradeOutcomeCommandHandler` sadece `MaxDrawdownAllTimePct` (0.25) bakıyordu; `MaxDrawdown24hPct` (0.05) hiç kontrol edilmiyordu.

## Fix
- `RiskProfile.TripIfDrawdownBreached(now)` private helper — `effectiveCeiling = min(24h, allTime)`. Hem `RecordTradeOutcome` hem `RecordPeakEquitySnapshot` çağırır.
- `RecordTradeOutcomeCommand` handler'daki duplike trip mantığı silindi (audit log kaldı).
- `EquityPeakTrackerService` XML doc + tracker-tripped audit log.

## Test
115/115 pass (109 + 6 regression).

## ADR uyum
- ADR-0011 §11.7 risk tracking semantik korundu.
- ADR-0012 §12.3 stop-loss orthogonal.