### PR TITLE
Loop 33 boot: AtrScalperVwapEma1m + SOL/ADA + ETH TP %0.50 (closes #39)

### DIFF
--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -33,7 +33,7 @@
   "Binance": {
     "RestBaseUrl": "https://testnet.binance.vision",
     "WsBaseUrl": "wss://stream.testnet.binance.vision",
-    "Symbols": [ "BTCUSDT", "ETHUSDT", "BNBUSDT", "XRPUSDT" ],
+    "Symbols": [ "BTCUSDT", "ETHUSDT", "BNBUSDT", "XRPUSDT", "SOLUSDT", "ADAUSDT" ],
     "KlineIntervals": [ "1m" ],
     "DepthSnapshotLimit": 1000,
     "RestTimeoutMs": 10000,
@@ -74,7 +74,7 @@
         "Name": "ETH-MicroScalper",
         "Type": "MicroScalperVwapEma30s",
         "Symbols": [ "ETHUSDT" ],
-        "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.007,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.3,\"SlopeTolerance\":-0.003,\"TpGrossPct\":0.003,\"StopPct\":0.0015,\"MaxHoldMinutes\":8}",
+        "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.007,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.3,\"SlopeTolerance\":-0.003,\"TpGrossPct\":0.005,\"StopPct\":0.0025,\"MaxHoldMinutes\":8}",
         "Activate": true
       },
       {
@@ -82,13 +82,27 @@
         "Type": "MicroScalperVwapEma30s",
         "Symbols": [ "BNBUSDT" ],
         "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.006,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.3,\"SlopeTolerance\":-0.003,\"TpGrossPct\":0.002,\"StopPct\":0.0012,\"MaxHoldMinutes\":5}",
-        "Activate": true
+        "Activate": false
       },
       {
         "Name": "XRP-MicroScalper",
         "Type": "MicroScalperVwapEma30s",
         "Symbols": [ "XRPUSDT" ],
         "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.010,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.3,\"SlopeTolerance\":-0.003,\"TpGrossPct\":0.004,\"StopPct\":0.002,\"MaxHoldMinutes\":7}",
+        "Activate": true
+      },
+      {
+        "Name": "SOL-AtrScalper",
+        "Type": "AtrScalperVwapEma1m",
+        "Symbols": [ "SOLUSDT" ],
+        "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.008,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.5,\"SlopeTolerance\":-0.003,\"AtrPeriod\":14,\"TpAtrMultiplier\":1.5,\"SlAtrMultiplier\":0.8,\"MinTpPct\":0.005,\"MaxTpPct\":0.012,\"MinSlPct\":0.0025,\"MaxSlPct\":0.006,\"MaxHoldMinutes\":6}",
+        "Activate": true
+      },
+      {
+        "Name": "ADA-AtrScalper",
+        "Type": "AtrScalperVwapEma1m",
+        "Symbols": [ "ADAUSDT" ],
+        "ParametersJson": "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20,\"VwapWindowBars\":15,\"VwapTolerancePct\":0.010,\"VolumeSmaBars\":20,\"VolumeMultiplier\":0.3,\"SlopeTolerance\":-0.003,\"AtrPeriod\":14,\"TpAtrMultiplier\":1.4,\"SlAtrMultiplier\":0.7,\"MinTpPct\":0.004,\"MaxTpPct\":0.010,\"MinSlPct\":0.002,\"MaxSlPct\":0.005,\"MaxHoldMinutes\":8}",
         "Activate": true
       }
     ]

--- a/src/Application/Strategies/Indicators/MicroScalperIndicatorSnapshot.cs
+++ b/src/Application/Strategies/Indicators/MicroScalperIndicatorSnapshot.cs
@@ -16,6 +16,14 @@ namespace BinanceBot.Application.Strategies.Indicators;
 /// <param name="Ema20Now">Son bar EMA20 değeri.</param>
 /// <param name="Ema20Prev">Bir önceki bar EMA20 değeri — slope gate için.</param>
 /// <param name="AsOf">Son kapalı 30s bar close time.</param>
+/// <param name="Atr14">
+/// Loop 33 — son 14 bar Average True Range. AtrScalperVwapEma1m evaluator TP/SL
+/// geometrisini volatilite rejimine göre adaptif ölçeklemek için kullanır
+/// (<c>TpPrice = entry ± TpAtrMultiplier × Atr14</c>). Eski MicroScalper evaluator
+/// bu alana dokunmaz, backward-compat için default <c>0</c>. Warmup tamamlanmadan
+/// (14+1 bar altında) <c>0</c> döner — evaluator <c>MinTpPct/MaxTpPct</c> clip ile
+/// degenerate case'i güvenli biçimde handle eder.
+/// </param>
 public sealed record MicroScalperIndicatorSnapshot(
     decimal Vwap,
     decimal PrevBarClose,
@@ -24,4 +32,5 @@ public sealed record MicroScalperIndicatorSnapshot(
     decimal VolumeSma20,
     decimal Ema20Now,
     decimal Ema20Prev,
-    DateTimeOffset AsOf);
+    DateTimeOffset AsOf,
+    decimal Atr14 = 0m);

--- a/src/Domain/Strategies/StrategyEnums.cs
+++ b/src/Domain/Strategies/StrategyEnums.cs
@@ -21,6 +21,11 @@ public enum StrategyStatus
 /// discount). <see cref="VwapEmaHybrid"/> enum ordinali korunur (Loop 19 pattern) —
 /// DB reseed ile eski seed'ler silinir, kod yüzeyinde <c>VwapEmaStrategyEvaluator</c>
 /// deprecated olarak kalır (backward-compat ParametersJson).
+///
+/// Loop 33 AR-GE Strateji D: <see cref="AtrScalperVwapEma1m"/> value <c>3</c> added.
+/// 1m kline VWAP reclaim + EMA20 slope + ATR14 çarpanlı dinamik TP/SL — fee/gross
+/// oranını yüksek-volatiliteli semboller (SOL, ADA) üzerinden %85 yerine %24'e
+/// indirir. MicroScalper ile aynı filtre geometrisi; tek fark TP/SL ATR-adaptif.
 /// </summary>
 public enum StrategyType
 {
@@ -31,6 +36,14 @@ public enum StrategyType
     /// Evaluator: <c>MicroScalperVwapEma30sEvaluator</c>.
     /// </summary>
     MicroScalperVwapEma30s = 2,
+
+    /// <summary>
+    /// Loop 33 AR-GE (Strateji D) — 1m kline VWAP reclaim + EMA20 slope + ATR14
+    /// çarpanlı dinamik TP/SL. Evaluator: <c>AtrScalperVwapEmaEvaluator</c>. Yüksek
+    /// volatiliteli altcoin rotasyonu (SOL, ADA) için çalışır; BTC/ETH/BNB/XRP için
+    /// MicroScalperVwapEma30s geometrisi korunur.
+    /// </summary>
+    AtrScalperVwapEma1m = 3,
 }
 
 public enum StrategySignalDirection

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -160,6 +160,9 @@ public static class DependencyInjection
         // ADR-0018 §18.11 — MicroScalper evaluator registered alongside the deprecated
         // VwapEma evaluator; registry dispatches by StrategyType enum value.
         services.AddSingleton<IStrategyEvaluator, MicroScalperVwapEma30sEvaluator>();
+        // Loop 33 AR-GE (Strateji D) — AtrScalper evaluator, MicroScalper ile aynı
+        // IMarketIndicatorService snapshot kaynağını tüketir (yeni Atr14 alanı).
+        services.AddSingleton<IStrategyEvaluator, AtrScalperVwapEmaEvaluator>();
         services.AddSingleton<StrategyEvaluatorRegistry>();
 
         services.AddOptions<StrategySeedOptions>()

--- a/src/Infrastructure/Strategies/Evaluators/AtrScalperVwapEmaEvaluator.cs
+++ b/src/Infrastructure/Strategies/Evaluators/AtrScalperVwapEmaEvaluator.cs
@@ -1,0 +1,255 @@
+using BinanceBot.Application.Strategies.Evaluation;
+using BinanceBot.Application.Strategies.Indicators;
+using BinanceBot.Domain.MarketData;
+using BinanceBot.Domain.Strategies;
+using Microsoft.Extensions.Logging;
+
+namespace BinanceBot.Infrastructure.Strategies.Evaluators;
+
+/// <summary>
+/// Loop 33 AR-GE (Strateji D) — 1m kline VWAP reclaim + EMA20 slope + volume
+/// confirm + ATR14 çarpanlı dinamik TP/SL micro-scalper. MicroScalperVwapEma30s
+/// evaluator'ünün %80'ini (filtre geometrisi) koruyarak yalnızca TP/SL hedefini
+/// sabit yüzde yerine <c>entry ± multiplier × ATR14</c> olarak hesaplar.
+///
+/// AR-GE motivasyonu (<c>loops/loop_33/strategy-arge.md</c> §1–§3):
+///   - BNB break-even WR %90.8, ETH %71.2 — sabit %0.2–0.3 TP, round-trip fee
+///     tarafından yutuluyordu (fee/gross %85). ATR-tabanlı TP yüksek vol
+///     dönemlerinde $0.50–0.70 hedef sağlar; fee/gross %24'e düşer.
+///   - SOL/ADA gibi yüksek-ATR semboller break-even WR'ı %49.5'e indirir —
+///     MicroScalper'dan 12 puan daha ulaşabilir eşik.
+///
+/// Giriş (<see cref="StrategySignalDirection.Long"/>, kapalı 1m bar sonrası):
+///   1. Direction gate  — <c>emaNow &gt; emaPrev × (1 + SlopeTolerance)</c>.
+///      Default <c>SlopeTolerance = -0.003</c> (AR-GE önerisi) → hafif
+///      negatif slope'a izin verir (pullback giriş); MicroScalper default'u
+///      da aynı.
+///   2. VWAP context    — önceki bar kapanışı VWAP altında (pullback).
+///   3. VWAP reclaim    — son bar kapanışı VWAP üstünde veya tolerans
+///      zone'unda (<see cref="Parameters.VwapTolerancePct"/>).
+///   4. Volume confirm  — <c>lastVolume &gt;= volumeSma20 × VolumeMultiplier</c>.
+///      Default multiplier 0.5 (high-vol altcoin spike rejection).
+///
+/// Çıkış (ATR14-tabanlı adaptif geometri):
+///   - Take-Profit: <c>entry × (1 + pct)</c> nerede
+///     <c>pct = clamp(ATR14 × TpAtrMultiplier / entry, MinTpPct, MaxTpPct)</c>.
+///   - Stop-Loss  : <c>entry × (1 − clamp(ATR14 × SlAtrMultiplier / entry,
+///     MinSlPct, MaxSlPct))</c>.
+///   - Time-Stop  : <c>MaxHoldMinutes</c> (default 6) — ContextJson
+///     <c>maxHoldMinutes</c> anahtarına yazılır (ADR-0017 §17.7 uyumlu).
+///
+/// Fallback (ATR14 = 0, warmup incomplete veya flat piyasa):
+///   Evaluator <see cref="Parameters.TpGrossPct"/> / <see cref="Parameters.StopPct"/>
+///   alanlarına düşer (backward-compat; default 0 ise MinTp/MinSl clip devreye
+///   girer). Bu yol <c>ContextJson.mode = "atr-fallback"</c> olarak işaretlenir.
+///
+/// Evaluator hiçbir DB bağlantısı açmaz, rolling buffer yönetmez — tüm primitive
+/// verileri <see cref="IMarketIndicatorService.TryGetMicroScalperSnapshot"/>
+/// üzerinden alır; <c>Atr14</c> alanı Loop 33'te eklendi.
+/// </summary>
+public sealed class AtrScalperVwapEmaEvaluator : IStrategyEvaluator
+{
+    public StrategyType Type => StrategyType.AtrScalperVwapEma1m;
+
+    private readonly IMarketIndicatorService _indicators;
+    private readonly ILogger<AtrScalperVwapEmaEvaluator> _logger;
+
+    public AtrScalperVwapEmaEvaluator(
+        IMarketIndicatorService indicators,
+        ILogger<AtrScalperVwapEmaEvaluator> logger)
+    {
+        _indicators = indicators;
+        _logger = logger;
+    }
+
+    public Task<StrategyEvaluation?> EvaluateAsync(
+        long strategyId,
+        string parametersJson,
+        string symbol,
+        IReadOnlyList<Kline> closedBars,
+        CancellationToken cancellationToken)
+    {
+        var p = EvaluatorParameterHelper.TryParse<Parameters>(parametersJson) ?? new Parameters();
+
+        var snapshot = _indicators.TryGetMicroScalperSnapshot(symbol);
+        if (snapshot is null)
+        {
+            _logger.LogDebug(
+                "AtrScalper snapshot not ready symbol={Symbol} strategyId={StrategyId}",
+                symbol, strategyId);
+            return Task.FromResult<StrategyEvaluation?>(null);
+        }
+
+        // Pre-warmup safety — degenerate zero values protect against flat / empty
+        // volume windows. Atr14 == 0 is tolerated here (fallback path below).
+        if (snapshot.Vwap <= 0m
+            || snapshot.VolumeSma20 <= 0m
+            || snapshot.Ema20Now <= 0m
+            || snapshot.Ema20Prev <= 0m)
+        {
+            _logger.LogDebug(
+                "AtrScalper snapshot incomplete symbol={Symbol} vwap={Vwap} volSma={Vol} ema={Ema}",
+                symbol, snapshot.Vwap, snapshot.VolumeSma20, snapshot.Ema20Now);
+            return Task.FromResult<StrategyEvaluation?>(null);
+        }
+
+        // §18.8 style — direction gate with negative slope tolerance allowed by
+        // default (pullback context).
+        var slopeGateLevel = snapshot.Ema20Prev * (1m + p.SlopeTolerance);
+        var directionGate = snapshot.Ema20Now > slopeGateLevel;
+
+        var vwapContext = snapshot.PrevBarClose < snapshot.Vwap;
+
+        var vwapAboveReclaim = snapshot.LastBarClose > snapshot.Vwap;
+        var vwapDistance = snapshot.Vwap > 0m
+            ? Math.Abs(snapshot.LastBarClose - snapshot.Vwap) / snapshot.Vwap
+            : decimal.MaxValue;
+        var vwapZoneOk = p.VwapTolerancePct > 0m && vwapDistance < p.VwapTolerancePct;
+        var vwapReclaim = vwapAboveReclaim || vwapZoneOk;
+
+        var volumeRatio = snapshot.VolumeSma20 > 0m
+            ? snapshot.LastBarVolume / snapshot.VolumeSma20
+            : 0m;
+        var volumeConfirm = volumeRatio >= p.VolumeMultiplier;
+
+        if (!directionGate || !vwapContext || !vwapReclaim || !volumeConfirm)
+        {
+            var slope = snapshot.Ema20Prev > 0m
+                ? (snapshot.Ema20Now - snapshot.Ema20Prev) / snapshot.Ema20Prev
+                : 0m;
+            _logger.LogDebug(
+                "AtrScalper skip symbol={Symbol} slope={Slope} slopeGate={GateLevel} " +
+                "vwapCtx={Below} reclaim={Reclaim} vwapZoneOk={ZoneOk} volRatio={Ratio} decision=Skip",
+                symbol, slope, slopeGateLevel,
+                vwapContext, vwapAboveReclaim, vwapZoneOk, volumeRatio);
+            return Task.FromResult<StrategyEvaluation?>(null);
+        }
+
+        var entryPrice = snapshot.LastBarClose;
+
+        // AR-GE §5 — ATR14 tabanlı dinamik geometri. ATR14 = 0 fallback'inde
+        // backward-compat TpGrossPct / StopPct alanlarına düşer; her iki modda
+        // da Min/Max clip uygulanır (SOL/ADA ATR saatlik %0.3–0.8 — tipik
+        // değerlerde clip bağlayıcı değil).
+        decimal tpPct;
+        decimal slPct;
+        string mode;
+
+        if (snapshot.Atr14 > 0m && entryPrice > 0m)
+        {
+            var rawTpPct = snapshot.Atr14 * p.TpAtrMultiplier / entryPrice;
+            var rawSlPct = snapshot.Atr14 * p.SlAtrMultiplier / entryPrice;
+            tpPct = Clamp(rawTpPct, p.MinTpPct, p.MaxTpPct);
+            slPct = Clamp(rawSlPct, p.MinSlPct, p.MaxSlPct);
+            mode = "atr-dynamic";
+        }
+        else
+        {
+            // Fallback — backward-compat with MicroScalper fixed-pct contract.
+            // Clip still applies so zero defaults don't produce invalid geometry.
+            tpPct = Clamp(p.TpGrossPct, p.MinTpPct, p.MaxTpPct);
+            slPct = Clamp(p.StopPct, p.MinSlPct, p.MaxSlPct);
+            mode = "atr-fallback";
+        }
+
+        var takeProfit = entryPrice * (1m + tpPct);
+        var stopPrice = entryPrice * (1m - slPct);
+
+        if (takeProfit <= entryPrice || stopPrice >= entryPrice)
+        {
+            _logger.LogDebug(
+                "AtrScalper geometry invalid symbol={Symbol} entry={Entry} stop={Stop} tp={Tp} mode={Mode}",
+                symbol, entryPrice, stopPrice, takeProfit, mode);
+            return Task.FromResult<StrategyEvaluation?>(null);
+        }
+
+        var slopeRatio = snapshot.Ema20Prev > 0m
+            ? (snapshot.Ema20Now - snapshot.Ema20Prev) / snapshot.Ema20Prev
+            : 0m;
+
+        // ContextJson — TimeStop handler (ADR-0017 §17.7) `maxHoldMinutes` key
+        // şartı korunur. Ek olarak ATR metadatası loglamaya akar.
+        var ctx = EvaluatorParameterHelper.SerializeContext(new
+        {
+            type = "atr-scalper-vwap-ema-1m",
+            mode,
+            vwap = snapshot.Vwap,
+            ema20Now = snapshot.Ema20Now,
+            ema20Prev = snapshot.Ema20Prev,
+            slope = slopeRatio,
+            prevBarClose = snapshot.PrevBarClose,
+            lastBarClose = snapshot.LastBarClose,
+            vwapDistance,
+            volumeRatio,
+            atr14 = snapshot.Atr14,
+            tpAtrMultiplier = p.TpAtrMultiplier,
+            slAtrMultiplier = p.SlAtrMultiplier,
+            tpPct,
+            slPct,
+            maxHoldMinutes = p.MaxHoldMinutes,
+        });
+
+        _logger.LogInformation(
+            "AtrScalper emit symbol={Symbol} entry={Entry} stop={Stop} tp={Tp} " +
+            "atr14={Atr} tpPct={TpPct} slPct={SlPct} mode={Mode} decision=Emit",
+            symbol, entryPrice, stopPrice, takeProfit,
+            snapshot.Atr14, tpPct, slPct, mode);
+
+        // SuggestedQuantity placeholder — fan-out handler (StrategySignalToOrderHandler)
+        // sizing service üzerinden ADR-0021 %20 equity / $20.10 floor rule ile
+        // gerçek miktarı hesaplar. Pozitif-ama-küçük değer
+        // StrategySignal.Emit domain invariant'ını (quantity > 0) karşılar.
+        return Task.FromResult<StrategyEvaluation?>(new StrategyEvaluation(
+            Direction: StrategySignalDirection.Long,
+            SuggestedQuantity: 0.00000001m,
+            SuggestedPrice: entryPrice,
+            SuggestedStopPrice: stopPrice,
+            ContextJson: ctx,
+            SuggestedTakeProfit: takeProfit));
+    }
+
+    private static decimal Clamp(decimal value, decimal min, decimal max)
+    {
+        if (min > 0m && value < min) return min;
+        if (max > 0m && value > max) return max;
+        return value;
+    }
+
+    /// <summary>
+    /// AR-GE §5 ve Implementation Roadmap — parametre kontratı. Serialised as
+    /// <c>Strategies.Seed[].ParametersJson</c>. MicroScalper ile uyumlu taban +
+    /// yeni ATR alanları.
+    /// </summary>
+    private sealed class Parameters
+    {
+        public string KlineInterval { get; set; } = "1m";
+        public string EmaTimeframe { get; set; } = "1m";
+        public int EmaPeriod { get; set; } = 20;
+
+        public int VwapWindowBars { get; set; } = 15;
+        public decimal VwapTolerancePct { get; set; } = 0.008m;
+
+        public int VolumeSmaBars { get; set; } = 20;
+        public decimal VolumeMultiplier { get; set; } = 0.5m;
+
+        public decimal SlopeTolerance { get; set; } = -0.003m;
+
+        // Loop 33 AR-GE §5 — ATR-adaptif TP/SL.
+        public int AtrPeriod { get; set; } = 14;
+        public decimal TpAtrMultiplier { get; set; } = 1.5m;
+        public decimal SlAtrMultiplier { get; set; } = 0.8m;
+
+        // Clip çiti — degenerate ATR (0 veya flat piyasa) + aşırı vol spike
+        // için üst/alt emniyet. AR-GE SOL önerisi: TP [0.005, 0.012].
+        public decimal MinTpPct { get; set; } = 0.004m;
+        public decimal MaxTpPct { get; set; } = 0.012m;
+        public decimal MinSlPct { get; set; } = 0.002m;
+        public decimal MaxSlPct { get; set; } = 0.008m;
+
+        // Backward-compat fallback alanları. ATR14 = 0 durumunda kullanılır.
+        public decimal TpGrossPct { get; set; } = 0m;
+        public decimal StopPct { get; set; } = 0m;
+
+        public int MaxHoldMinutes { get; set; } = 6;
+    }
+}

--- a/src/Infrastructure/Strategies/Indicators/MarketIndicatorService.cs
+++ b/src/Infrastructure/Strategies/Indicators/MarketIndicatorService.cs
@@ -159,9 +159,22 @@ public sealed class MarketIndicatorService : IMarketIndicatorService, IHostedSer
     }
 
     /// <summary>
-    /// ADR-0018 §18.11 — 30sn bar bazında MicroScalper snapshot'ını üretir.
-    /// Warmup: 15-bar VWAP + 20-bar EMA + 20-bar volume SMA → en az 21 bar.
-    /// Hiç bar yoksa veya warmup tamamlanmadıysa <c>null</c>.
+    /// ADR-0018 §18.11 — MicroScalper snapshot'ı.
+    ///
+    /// Loop 24 runtime bug-fix: Binance SPOT WebSocket <c>@kline_30s</c>'i
+    /// desteklemez (bkz. binance-spot-api-docs: valid kline intervals =
+    /// 1s,1m,3m,5m,15m,30m,1h,…). Testnet SPOT stream 30s subscription'ını
+    /// sessizce reddediyordu ve <c>state.ThirtySecond</c> buffer'ı hiçbir zaman
+    /// dolmuyordu (20 dk runtime = 0 bar). Evaluator path bu yüzden hiç
+    /// çağrılmadı (0 emit, 0 skip).
+    ///
+    /// Geçici çözüm: snapshot artık <c>state.OneMinute</c> buffer'ından
+    /// hesaplanıyor — KlineIngestionWorker ve warmup REST path ikisi de 1m
+    /// bar'ları doldurur. Warmup 1440 bar REST backfill ile anında tamamlanır.
+    /// Parametreler (<c>TpGrossPct=0.006</c>, <c>StopPct=0.0035</c>,
+    /// <c>MaxHoldMinutes=2</c>) değişmez ama artık 1m bar bazında uygulanır.
+    /// Strateji tipinin adı (<c>MicroScalperVwapEma30s</c>) geriye dönük uyumluluk
+    /// için korunuyor; ADR-0018 §18.6 revizyonu binance-expert tarafından yapılacak.
     /// </summary>
     public MicroScalperIndicatorSnapshot? TryGetMicroScalperSnapshot(string symbol)
     {
@@ -177,29 +190,35 @@ public sealed class MarketIndicatorService : IMarketIndicatorService, IHostedSer
 
         lock (state.SyncRoot)
         {
-            var thirtyBars = state.ThirtySecond.Snapshot();
+            // Loop 24: 1m buffer'ı kullan (30s spot WS tarafından desteklenmiyor).
+            var bars = state.OneMinute.Snapshot();
 
-            // ADR-0018 §18.11 — 30s warmup eşiği: EMA20 + VolumeSMA20 hesaplanabilir
-            // olmalı + önceki EMA değeri için +1 bar gerekli. 21 bar minimumu safe.
-            if (thirtyBars.Count < 21)
+            // Warmup eşiği: EMA20 + VolumeSMA20 hesaplanabilir + önceki EMA için +1 bar.
+            if (bars.Count < 21)
             {
                 return null;
             }
 
-            // VWAP rolling 15-bar: toplam bar 21 olsa bile VWAP yalnızca son 15 bar'dan
-            // hesaplanır (ADR-0018 §18.7 VwapWindowBars=15).
-            var klines30s = ToKlineList(thirtyBars);
-            var vwapWindow = klines30s.Count <= 15
-                ? klines30s
-                : (IReadOnlyList<Kline>)klines30s.GetRange(klines30s.Count - 15, 15);
+            // VWAP rolling 15-bar: toplam bar sayısı fazla olsa bile son 15 bar.
+            var klines = ToKlineList(bars);
+            var vwapWindow = klines.Count <= 15
+                ? klines
+                : (IReadOnlyList<Kline>)klines.GetRange(klines.Count - 15, 15);
 
             var vwap = Evaluators.Indicators.Vwap(vwapWindow);
-            var volumeSma20 = Evaluators.Indicators.VolumeSma(klines30s, 20);
-            var ema20Now = Evaluators.Indicators.Ema(klines30s, period: 20, endIndex: klines30s.Count - 1);
-            var ema20Prev = Evaluators.Indicators.Ema(klines30s, period: 20, endIndex: klines30s.Count - 2);
+            var volumeSma20 = Evaluators.Indicators.VolumeSma(klines, 20);
+            var ema20Now = Evaluators.Indicators.Ema(klines, period: 20, endIndex: klines.Count - 1);
+            var ema20Prev = Evaluators.Indicators.Ema(klines, period: 20, endIndex: klines.Count - 2);
 
-            var lastBar = klines30s[^1];
-            var prevBar = klines30s[^2];
+            // Loop 33 (AR-GE Strateji D) — ATR14 snapshot alanı. AtrScalperVwapEma1m
+            // evaluator TP/SL geometrisini volatilite rejimine adaptif ölçekler.
+            // Indicators.Atr() bar < period+1 ise 0 döner; evaluator MinTp/MaxTp
+            // clip ile degenerate-case'i güvenle handle eder. 21-bar warmup eşiği
+            // 14-period ATR için zaten yeterli (15 bar minimum).
+            var atr14 = Evaluators.Indicators.Atr(klines, period: 14);
+
+            var lastBar = klines[^1];
+            var prevBar = klines[^2];
 
             return new MicroScalperIndicatorSnapshot(
                 Vwap: vwap,
@@ -209,7 +228,8 @@ public sealed class MarketIndicatorService : IMarketIndicatorService, IHostedSer
                 VolumeSma20: volumeSma20,
                 Ema20Now: ema20Now,
                 Ema20Prev: ema20Prev,
-                AsOf: lastBar.CloseTime);
+                AsOf: lastBar.CloseTime,
+                Atr14: atr14);
         }
     }
 
@@ -318,16 +338,11 @@ public sealed class MarketIndicatorService : IMarketIndicatorService, IHostedSer
 
             await WarmupOneAsync(marketData, symbol, KlineInterval.OneMinute, OneMinuteBufferCapacity, ct);
             await WarmupOneAsync(marketData, symbol, KlineInterval.OneHour, OneHourBufferCapacity, ct);
-            // Loop 23 blocker fix (BLOCKER-1): Binance REST /api/v3/klines does NOT
-            // support interval=30s (only WS streams do). Calling it returns 400.
-            // 30s buffer fills from the live WS consumer loop below; MicroScalper
-            // evaluator skip-returns while TryGetMicroScalperSnapshot is null
-            // (~10 min until 21-bar threshold, accepted trade-off).
-            _logger.LogInformation(
-                "MarketIndicator warmup {Symbol} {Interval}: REST backfill skipped (Binance " +
-                "does not support 30s on REST); WS stream will accumulate bars (~10 min to reach " +
-                "21-bar threshold)",
-                symbol, KlineInterval.ThirtySeconds);
+            // Loop 24 bug-fix: 30s bar path deprecated — Binance SPOT WS does NOT
+            // support @kline_30s (SPOT valid intervals: 1s,1m,3m,…). TryGetMicroScalperSnapshot
+            // now reads state.OneMinute directly, so no separate 30s warmup needed.
+            // state.ThirtySecond buffer remains (consumer loop keeps accepting 30s
+            // bars if ever sent) but is intentionally unused downstream.
 
             // ADR-0016 §16.9.6 — emit per-symbol warmup completion marker.
             await MaybePublishWarmupAsync(symbol, ct);

--- a/tests/Tests/Infrastructure/Strategies/AtrScalperVwapEmaEvaluatorTests.cs
+++ b/tests/Tests/Infrastructure/Strategies/AtrScalperVwapEmaEvaluatorTests.cs
@@ -1,0 +1,277 @@
+using BinanceBot.Application.Strategies.Indicators;
+using BinanceBot.Domain.MarketData;
+using BinanceBot.Domain.Strategies;
+using BinanceBot.Infrastructure.Strategies.Evaluators;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BinanceBot.Tests.Infrastructure.Strategies;
+
+/// <summary>
+/// Loop 33 AR-GE (Strateji D) contract — <see cref="AtrScalperVwapEmaEvaluator"/>
+/// MicroScalper filter gate'lerini korur ancak TP/SL'i ATR14 çarpanları ile
+/// dinamik hesaplar. Test kapsamı:
+///   1. Filter gate'leri (slope / VWAP context / VWAP reclaim / volume) —
+///      MicroScalper ile aynı davranış.
+///   2. ATR dinamik TP/SL — <c>atr14 × multiplier / entry</c> clip içinde.
+///   3. ATR clip — Min/Max sınırlarında çit bağlayıcı.
+///   4. ATR fallback — <c>atr14 = 0</c> iken <c>TpGrossPct/StopPct</c> fallback.
+///   5. SlopeTolerance sınırı — AR-GE default -0.003 hafif negatif slope'a izin.
+/// </summary>
+public class AtrScalperVwapEmaEvaluatorTests
+{
+    private const string Symbol = "SOLUSDT";
+
+    // AR-GE §5 SOL-AtrScalper seed parametreleri (clip çitleri loose — ATR
+    // multiplier testlerinde bağlayıcı değil).
+    private static readonly string DefaultParams =
+        "{\"KlineInterval\":\"1m\",\"EmaTimeframe\":\"1m\",\"EmaPeriod\":20," +
+        "\"VwapWindowBars\":15,\"VwapTolerancePct\":0.008,\"VolumeSmaBars\":20," +
+        "\"VolumeMultiplier\":0.5,\"SlopeTolerance\":-0.003," +
+        "\"AtrPeriod\":14,\"TpAtrMultiplier\":1.5,\"SlAtrMultiplier\":0.8," +
+        "\"MinTpPct\":0.001,\"MaxTpPct\":0.050,\"MinSlPct\":0.0005,\"MaxSlPct\":0.025," +
+        "\"MaxHoldMinutes\":6}";
+
+    private static (AtrScalperVwapEmaEvaluator Sut, Mock<IMarketIndicatorService> Indicators)
+        Build(MicroScalperIndicatorSnapshot? snapshot, string symbol = Symbol)
+    {
+        var mock = new Mock<IMarketIndicatorService>();
+        mock.Setup(i => i.TryGetMicroScalperSnapshot(symbol)).Returns(snapshot);
+        var sut = new AtrScalperVwapEmaEvaluator(
+            mock.Object, NullLogger<AtrScalperVwapEmaEvaluator>.Instance);
+        return (sut, mock);
+    }
+
+    private static MicroScalperIndicatorSnapshot HappySnapshot(
+        decimal vwap = 100m,
+        decimal prevBarClose = 99.8m,     // below vwap (pullback)
+        decimal lastBarClose = 100.2m,    // above vwap (reclaim)
+        decimal lastBarVolume = 160m,     // 1.6× sma20 → clears 0.5 multiplier
+        decimal volumeSma20 = 100m,
+        decimal ema20Now = 100.05m,       // rising (slope > 0)
+        decimal ema20Prev = 100.00m,
+        decimal atr14 = 0.5m)             // ATR = 0.50 @ price 100.2 → ~%0.499
+    {
+        return new MicroScalperIndicatorSnapshot(
+            Vwap: vwap,
+            PrevBarClose: prevBarClose,
+            LastBarClose: lastBarClose,
+            LastBarVolume: lastBarVolume,
+            VolumeSma20: volumeSma20,
+            Ema20Now: ema20Now,
+            Ema20Prev: ema20Prev,
+            AsOf: DateTimeOffset.UtcNow,
+            Atr14: atr14);
+    }
+
+    [Fact]
+    public void Type_IsAtrScalperVwapEma1m()
+    {
+        var (sut, _) = Build(snapshot: null);
+        sut.Type.Should().Be(StrategyType.AtrScalperVwapEma1m);
+    }
+
+    [Fact]
+    public async Task NullSnapshot_ReturnsNullSignal()
+    {
+        var (sut, _) = Build(snapshot: null);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AllConditionsMet_WithAtr_EmitsLong_DynamicGeometry()
+    {
+        // entry=100.2, atr14=0.5, TpMult=1.5, SlMult=0.8
+        // rawTpPct = 0.5 * 1.5 / 100.2 = 0.007485...
+        // rawSlPct = 0.5 * 0.8 / 100.2 = 0.003992...
+        // Clip çitleri loose — bağlayıcı değil, raw değerler kullanılır.
+        // TP = 100.2 * (1 + 0.007485) = 100.95005
+        // SL = 100.2 * (1 - 0.003992) = 99.80000
+        var snapshot = HappySnapshot();
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Direction.Should().Be(StrategySignalDirection.Long);
+        result.SuggestedPrice.Should().Be(100.2m);
+        result.SuggestedTakeProfit.Should().BeApproximately(100.9500m, 0.0005m);
+        result.SuggestedStopPrice.Should().BeApproximately(99.8000m, 0.0005m);
+        result.ContextJson.Should().Contain("atr-scalper-vwap-ema-1m");
+        result.ContextJson.Should().Contain("atr-dynamic");
+        result.ContextJson.Should().Contain("atr14");
+        result.ContextJson.Should().Contain("maxHoldMinutes");
+    }
+
+    [Fact]
+    public async Task AtrZero_FallsBackTo_TpGrossPct_AndStopPct()
+    {
+        // Fallback path: ATR14 = 0 → TpGrossPct/StopPct kullanılır. Default
+        // params'ta bunlar 0 — fallback+clip MinTpPct/MinSlPct'ye sabitlenir.
+        var fallbackParams = DefaultParams.Replace(
+            "\"MaxHoldMinutes\":6",
+            "\"TpGrossPct\":0.006,\"StopPct\":0.0035,\"MaxHoldMinutes\":6");
+        var snapshot = HappySnapshot(atr14: 0m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, fallbackParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // TP = 100.2 * 1.006 = 100.8012
+        result!.SuggestedTakeProfit.Should().BeApproximately(100.8012m, 0.0005m);
+        // SL = 100.2 * 0.9965 = 99.8493
+        result.SuggestedStopPrice.Should().BeApproximately(99.8493m, 0.0005m);
+        result.ContextJson.Should().Contain("atr-fallback");
+    }
+
+    [Fact]
+    public async Task AtrExtreme_ClippedTo_MaxTpPct()
+    {
+        // Çok yüksek ATR (gerçek SOL ani spike senaryosu) — TP clip çitine
+        // sabitlenir. MaxTpPct=0.050 default params'ta; atr14=10 → raw≈%15.
+        var snapshot = HappySnapshot(atr14: 10m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // TP clip: 100.2 * 1.050 = 105.21
+        result!.SuggestedTakeProfit.Should().BeApproximately(105.21m, 0.01m);
+        // SL clip: 100.2 * (1 - 0.025) = 97.695
+        result.SuggestedStopPrice.Should().BeApproximately(97.695m, 0.01m);
+    }
+
+    [Fact]
+    public async Task SlopeTolerance_Negative_AllowsMildDownwardSlope()
+    {
+        // AR-GE SlopeTolerance = -0.003 hafif düşüş izni — emaNow 99.8 &
+        // emaPrev 100 → slope = -0.002 (> -0.003 gate). directionGate passes.
+        var snapshot = HappySnapshot(ema20Now: 99.8m, ema20Prev: 100m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Direction.Should().Be(StrategySignalDirection.Long);
+    }
+
+    [Fact]
+    public async Task SlopeTolerance_BreachedNegative_DoesNotEmit()
+    {
+        // slope = -0.01 < -0.003 → gate fails.
+        var snapshot = HappySnapshot(ema20Now: 99m, ema20Prev: 100m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task VwapContextMissing_PrevBarAboveVwap_DoesNotEmit()
+    {
+        // Pullback context required.
+        var snapshot = HappySnapshot(prevBarClose: 100.3m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task VwapReclaim_WithinTolerance_Emits()
+    {
+        // Last bar slightly below VWAP, ama VwapTolerancePct=0.008 zone içinde.
+        // distance = |99.95 - 100| / 100 = 0.0005 < 0.008 → zone ok.
+        var snapshot = HappySnapshot(lastBarClose: 99.95m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task VolumeBelowMultiplier_DoesNotEmit()
+    {
+        // 40 / 100 = 0.4 < 0.5 → volume gate fails.
+        var snapshot = HappySnapshot(lastBarVolume: 40m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task IncompleteSnapshot_ZeroVwap_DoesNotEmit()
+    {
+        // Degenerate zero-vwap snapshot (pre-warmup guard).
+        var snapshot = HappySnapshot(vwap: 0m);
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EmptyParameters_UsesDefaults_AndEmits()
+    {
+        // Empty params → Parameters defaults (VolMult 0.5, SlopeTol -0.003,
+        // TpMult 1.5, SlMult 0.8, Atr snapshot 0.5).
+        var snapshot = HappySnapshot();
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, parametersJson: "{}", Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Direction.Should().Be(StrategySignalDirection.Long);
+    }
+
+    [Fact]
+    public async Task ContextJson_Contains_AtrMetadataAndClippedPcts()
+    {
+        var snapshot = HappySnapshot();
+        var (sut, _) = Build(snapshot);
+
+        var result = await sut.EvaluateAsync(
+            strategyId: 1, DefaultParams, Symbol,
+            closedBars: Array.Empty<Kline>(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ContextJson.Should().Contain("tpAtrMultiplier");
+        result.ContextJson.Should().Contain("slAtrMultiplier");
+        result.ContextJson.Should().Contain("tpPct");
+        result.ContextJson.Should().Contain("slPct");
+        result.ContextJson.Should().Contain("volumeRatio");
+        result.ContextJson.Should().Contain("slope");
+    }
+}


### PR DESCRIPTION
## Summary
- **AtrScalperVwapEmaEvaluator** — MicroScalper %80 korunur, TP/SL dinamik `entry ± ATR14 × multiplier` + Min/Max clip
- **SOL + ADA** yeni sembol (AR-GE yüksek vol), **ETH TP %0.30 → %0.50**, **BNB Paused** (BE_WR %90.8), XRP devam
- **MicroScalperIndicatorSnapshot.Atr14** optional (BC), `MarketIndicatorService` ATR(14) hesaplar
- Migration yok — runtime seed sync

Closes #39

## Test plan
- [x] `dotnet build` 0/0
- [x] `dotnet test` 250/250 yeşil (+13 AtrScalper)
- [ ] API restart + appsettings Seeds sync kontrolü (SOL/ADA Strategies tablosuna insert)
- [ ] t15 health check: ATR snapshot değeri 0'dan büyük, TP/SL dinamik hesaplanıyor
- [ ] Loop 33 4h cycle başarı kriteri: min 10 trade, WR ≥ %55, net > +$0.10

## Commit
1. `8e31dc2` — Loop 33 boot: AtrScalperVwapEma1m + SOL/ADA seed + ETH TP %0.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)